### PR TITLE
Update drivers.py

### DIFF
--- a/src/drivers.py
+++ b/src/drivers.py
@@ -650,7 +650,7 @@ class ViperDriver(Driver):
         self.icp_btn("ENTR")
 
     def enter_coords(self, latlong):
-        lat_str, lon_str = latlon_tostring(latlong, decimal_minutes_mode=True, easting_zfill=3, zfill_minutes=3, one_digit_seconds=False, precision=3)
+        lat_str, lon_str = latlon_tostring(latlong, decimal_minutes_mode=True, easting_zfill=3, zfill_minutes=2, one_digit_seconds=False, precision=3)
         self.logger.debug(f"Entering coords string: {lat_str}, {lon_str}")
 
         if latlong.lat.degree > 0:


### PR DESCRIPTION
Fixed bug in Viper coordinate entry. Viper expects 2 digits in minutes. However, latlon_tostring was using zfill_minutes of 3 resulting in an extra "0" in the input.